### PR TITLE
Update GoogleDriveView.ui.xml

### DIFF
--- a/src/main/java/com/github/gwtmaterialdesign/client/application/googledrive/GoogleDriveView.ui.xml
+++ b/src/main/java/com/github/gwtmaterialdesign/client/application/googledrive/GoogleDriveView.ui.xml
@@ -21,7 +21,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:g="urn:import:com.google.gwt.user.client.ui"
              xmlns:m="urn:import:gwt.material.design.client.ui"
-             xmlns:m.addins="urn:import:gwt.material.design.addins.client.ui">
+             xmlns:m.addins="urn:import:gwt.material.design.addins.client">
     <ui:style>
         @external side-nav, active;
         body{


### PR DESCRIPTION
`gwt.material.design.addins.client.ui` throws an error since the package does not seem to exist anymore